### PR TITLE
Improve logging and texture unregistration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ migrate_working_dir/
 .flutter-plugins-dependencies
 build/
 target/
+
+*.log*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,7 +518,7 @@ dependencies = [
  "gdkx11",
  "gtk-sys",
  "irondash_dart_ffi",
- "irondash_engine_context 0.6.0",
+ "irondash_engine_context",
  "irondash_run_loop 0.6.0",
  "irondash_texture",
  "lazy_static",
@@ -1006,6 +1006,8 @@ dependencies = [
 [[package]]
 name = "irondash_dart_ffi"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ed3ea8413fd024d89154472f7aea14e820eb600d0c4318bc001b14dd9b3ddc"
 dependencies = [
  "once_cell",
 ]
@@ -1026,29 +1028,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "irondash_engine_context"
-version = "0.6.0"
-dependencies = [
- "android_logger 0.11.3",
- "core-foundation",
- "jni",
- "log",
- "objc2",
- "objc2-foundation",
- "once_cell",
-]
-
-[[package]]
 name = "irondash_run_loop"
-version = "0.6.0"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b669550085d7f2ecad1811118b36f57224dd83fddbc97da17009f429d637239d"
 dependencies = [
  "core-foundation",
  "futures",
- "irondash_engine_context 0.5.0",
+ "icrate",
+ "irondash_engine_context",
  "log",
  "objc2",
- "objc2-app-kit",
- "objc2-foundation",
  "once_cell",
 ]
 
@@ -1060,7 +1050,7 @@ checksum = "b4ad6b87faf3f88fd8e54cd5d33c9b1b0ab20baa9a2f11894f4b82e5a735f1cc"
 dependencies = [
  "core-foundation",
  "futures",
- "irondash_engine_context 0.5.0",
+ "irondash_engine_context",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -1071,14 +1061,16 @@ dependencies = [
 [[package]]
 name = "irondash_texture"
 version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b992468499fe05bc22fde60afe036ec7792d2582584b66ea6c93796e3aad72f2"
 dependencies = [
  "core-foundation",
  "cstr",
  "glib-sys 0.16.3",
  "gobject-sys 0.16.3",
  "icrate",
- "irondash_engine_context 0.5.0",
- "irondash_run_loop 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "irondash_engine_context",
+ "irondash_run_loop 0.5.0",
  "jni",
  "log",
  "ndk-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,7 +518,7 @@ dependencies = [
  "gdkx11",
  "gtk-sys",
  "irondash_dart_ffi",
- "irondash_engine_context",
+ "irondash_engine_context 0.6.0",
  "irondash_run_loop 0.6.0",
  "irondash_texture",
  "lazy_static",
@@ -1006,8 +1006,6 @@ dependencies = [
 [[package]]
 name = "irondash_dart_ffi"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ed3ea8413fd024d89154472f7aea14e820eb600d0c4318bc001b14dd9b3ddc"
 dependencies = [
  "once_cell",
 ]
@@ -1028,17 +1026,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "irondash_engine_context"
+version = "0.6.0"
+dependencies = [
+ "android_logger 0.11.3",
+ "core-foundation",
+ "jni",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "once_cell",
+]
+
+[[package]]
 name = "irondash_run_loop"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b669550085d7f2ecad1811118b36f57224dd83fddbc97da17009f429d637239d"
+version = "0.6.0"
 dependencies = [
  "core-foundation",
  "futures",
- "icrate",
- "irondash_engine_context",
+ "irondash_engine_context 0.5.0",
  "log",
  "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
  "once_cell",
 ]
 
@@ -1050,7 +1060,7 @@ checksum = "b4ad6b87faf3f88fd8e54cd5d33c9b1b0ab20baa9a2f11894f4b82e5a735f1cc"
 dependencies = [
  "core-foundation",
  "futures",
- "irondash_engine_context",
+ "irondash_engine_context 0.5.0",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -1061,16 +1071,14 @@ dependencies = [
 [[package]]
 name = "irondash_texture"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b992468499fe05bc22fde60afe036ec7792d2582584b66ea6c93796e3aad72f2"
 dependencies = [
  "core-foundation",
  "cstr",
  "glib-sys 0.16.3",
  "gobject-sys 0.16.3",
  "icrate",
- "irondash_engine_context",
- "irondash_run_loop 0.5.0",
+ "irondash_engine_context 0.5.0",
+ "irondash_run_loop 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jni",
  "log",
  "ndk-sys",

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -28,7 +28,6 @@ class MyApp extends StatelessWidget {
   }
 }
 
-
 class StreamControlWidget extends StatefulWidget {
   const StreamControlWidget({super.key});
 
@@ -41,6 +40,11 @@ class StreamControlWidgetState extends State<StreamControlWidget> {
   final TextEditingController _urlController = TextEditingController(
     text: "http://67.53.46.161:65123/mjpg/video.mjpg",
   );
+  @override
+  void dispose() {
+    _urlController.dispose();
+    super.dispose();
+  }
 
   void _toggleStream() {
     debugPrint("Toggle stream");

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,11 +4,12 @@ import 'package:flutter_realtime_player/video_player.dart';
 
 import 'package:window_manager/window_manager.dart';
 import 'package:flutter_realtime_player/flutter_realtime_player.dart' as fl_gst;
-
+import 'package:desktop_multi_window/desktop_multi_window.dart';
+import 'dart:convert';
 
 Future<void> main() async {
-    WidgetsFlutterBinding.ensureInitialized();
-    await fl_gst.init();
+  WidgetsFlutterBinding.ensureInitialized();
+  await fl_gst.init();
   await windowManager.ensureInitialized();
   runApp(const MyApp());
 }
@@ -23,11 +24,8 @@ class MyApp extends StatelessWidget {
         appBar: AppBar(title: const Text('flutter_rust_bridge quickstart')),
         body: StreamControlWidget(),
       ),
-    );   
+    );
   }
-  
-  
-  
 }
 
 class StreamControlWidget extends StatefulWidget {
@@ -35,18 +33,30 @@ class StreamControlWidget extends StatefulWidget {
 
   @override
   StreamControlWidgetState createState() => StreamControlWidgetState();
-  
 }
 
 class StreamControlWidgetState extends State<StreamControlWidget> {
   bool _isStreaming = true;
+  final TextEditingController _urlController = TextEditingController(
+    text: "http://67.53.46.161:65123/mjpg/video.mjpg",
+  );
 
-  
   void _toggleStream() {
-      debugPrint("Toggle stream");
+    debugPrint("Toggle stream");
     setState(() {
       _isStreaming = !_isStreaming;
     });
+  }
+
+  Future<void> _openInNewWindow() async {
+    final url = _urlController.text;
+    final window = await DesktopMultiWindow.createWindow(
+      jsonEncode({'url': url}),
+    );
+    window
+      ..setFrame(const Offset(100, 100) & const Size(800, 600))
+      ..setTitle('Stream Window')
+      ..show();
   }
 
   @override
@@ -54,24 +64,37 @@ class StreamControlWidgetState extends State<StreamControlWidget> {
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        ElevatedButton(
-          onPressed: _toggleStream,
-          child: Text(_isStreaming ? 'Stop Stream' : 'Start Stream'),
+        TextField(
+          controller: _urlController,
+          decoration: const InputDecoration(
+            labelText: 'Stream URL',
+            border: OutlineInputBorder(),
+          ),
+        ),
+        const SizedBox(height: 10),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            ElevatedButton(
+              onPressed: _toggleStream,
+              child: Text(_isStreaming ? 'Stop Stream' : 'Start Stream'),
+            ),
+            const SizedBox(width: 10),
+            ElevatedButton(
+              onPressed: _openInNewWindow,
+              child: const Text('Open in New Window'),
+            ),
+          ],
         ),
         const SizedBox(height: 20),
         _isStreaming
             ? SizedBox(
-                width: double.infinity,
-                height: 300,
-                child: VideoPlayer.fromConfig(
-                  url: "http://67.53.46.161:65123/mjpg/video.mjpg",
-                ),
-              )
+              width: double.infinity,
+              height: 300,
+              child: VideoPlayer.fromConfig(url: _urlController.text),
+            )
             : const Text('Stream is stopped'),
       ],
-      
-      
     );
   }
 }
-

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -28,6 +28,7 @@ class MyApp extends StatelessWidget {
   }
 }
 
+
 class StreamControlWidget extends StatefulWidget {
   const StreamControlWidget({super.key});
 

--- a/example/lib/stream_window_page.dart
+++ b/example/lib/stream_window_page.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_realtime_player/video_player.dart';
+
+class StreamWindowPage extends StatelessWidget {
+  final String url;
+  const StreamWindowPage({super.key, required this.url});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Stream Window')),
+      body: Center(
+        child: SizedBox(
+          width: double.infinity,
+          height: 300,
+          child: VideoPlayer.fromConfig(url: url),
+        ),
+      ),
+    );
+  }
+}

--- a/example/linux/runner/my_application.cc
+++ b/example/linux/runner/my_application.cc
@@ -4,8 +4,11 @@
 #ifdef GDK_WINDOWING_X11
 #include <gdk/gdkx.h>
 #endif
-
+#include <irondash_engine_context/irondash_engine_context_plugin.h>
+#include <screen_retriever_linux/screen_retriever_linux_plugin.h>
+#include <window_manager/window_manager_plugin.h>
 #include "flutter/generated_plugin_registrant.h"
+#include "desktop_multi_window/desktop_multi_window_plugin.h"
 
 struct _MyApplication {
   GtkApplication parent_instance;
@@ -56,7 +59,17 @@ static void my_application_activate(GApplication* application) {
   FlView* view = fl_view_new(project);
   gtk_widget_show(GTK_WIDGET(view));
   gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
-
+  desktop_multi_window_plugin_set_window_created_callback([](FlPluginRegistry* registry){
+        g_autoptr(FlPluginRegistrar) irondash_engine_context_registrar =
+        fl_plugin_registry_get_registrar_for_plugin(registry, "IrondashEngineContextPlugin");
+        irondash_engine_context_plugin_register_with_registrar(irondash_engine_context_registrar);
+        g_autoptr(FlPluginRegistrar) screen_retriever_linux_registrar =
+            fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverLinuxPlugin");
+        screen_retriever_linux_plugin_register_with_registrar(screen_retriever_linux_registrar);
+        g_autoptr(FlPluginRegistrar) window_manager_registrar =
+            fl_plugin_registry_get_registrar_for_plugin(registry, "WindowManagerPlugin");
+        window_manager_plugin_register_with_registrar(window_manager_registrar);
+      });
   fl_register_plugins(FL_PLUGIN_REGISTRY(view));
 
   gtk_widget_grab_focus(GTK_WIDGET(view));

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -65,6 +65,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  desktop_multi_window:
+    dependency: "direct main"
+    description:
+      name: desktop_multi_window
+      sha256: "3ea2d696e50c3df696aabfddbd98c220ab4dde38f12c2ab12d1103bfe00ae79b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   fake_async:
     dependency: transitive
     description:

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,10 +11,10 @@ crate-type = ["cdylib", "staticlib"]
 flutter_rust_bridge = "=2.9.0"
 
 # irondash
-irondash_texture = { path = "/home/dev/Desktop/OS/irondash/texture" }
-irondash_run_loop = { path = "/home/dev/Desktop/OS/irondash/run_loop" }
-irondash_engine_context = { path = "/home/dev/Desktop/OS/irondash/engine_context/rust" }
-irondash_dart_ffi = { path = "/home/dev/Desktop/OS/irondash/dart_ffi" }
+irondash_texture = "*"
+irondash_run_loop = "*"
+irondash_engine_context = "*"
+irondash_dart_ffi = "*"
 
 log = "0.4"
 anyhow = "1.0.81"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,10 +11,10 @@ crate-type = ["cdylib", "staticlib"]
 flutter_rust_bridge = "=2.9.0"
 
 # irondash
-irondash_texture = "*"
-irondash_run_loop = "*"
-irondash_engine_context = "*"
-irondash_dart_ffi = "*"
+irondash_texture = { path = "/home/dev/Desktop/OS/irondash/texture" }
+irondash_run_loop = { path = "/home/dev/Desktop/OS/irondash/run_loop" }
+irondash_engine_context = { path = "/home/dev/Desktop/OS/irondash/engine_context/rust" }
+irondash_dart_ffi = { path = "/home/dev/Desktop/OS/irondash/dart_ffi" }
 
 log = "0.4"
 anyhow = "1.0.81"

--- a/rust/src/api/simple.rs
+++ b/rust/src/api/simple.rs
@@ -56,10 +56,8 @@ pub fn destroy_engine_streams(engine_id: i64) {
     trace!("destroy_playable was called");
     // it is important to call this on the platform main thread
     // because irondash will unregister the texture on Drop, and drop must occur
-    // on the platform main thread
-    invoke_on_platform_main_thread(move || {
-        crate::core::fluttersink::destroy_engine_streams(engine_id)
-    });
+    // on the platform main thread    
+    crate::core::fluttersink::destroy_engine_streams(engine_id);
 }
 
 pub fn destroy_stream_session(texture_id: i64) {

--- a/rust/src/api/simple.rs
+++ b/rust/src/api/simple.rs
@@ -1,3 +1,4 @@
+use irondash_engine_context::EngineContext;
 use log::{debug, trace};
 
 use crate::{
@@ -15,7 +16,7 @@ pub fn init_app() {
     if *is_initialized {
         return;
     }
-    let log_file = tracing_appender::rolling::daily("./logs", "flutter_realtime_player");
+    let log_file = tracing_appender::rolling::daily("./logs", "flutter_realtime_player.log");
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .with_writer(log_file)
@@ -23,6 +24,7 @@ pub fn init_app() {
         .with_thread_names(true)
         .with_file(true)
         .with_line_number(true)
+        .with_ansi(false)
         .init();
     // Default utilities - feel free to custom
     flutter_rust_bridge::setup_default_user_utils();
@@ -46,7 +48,7 @@ pub fn flutter_realtime_player_init(ffi_ptr: i64) {
 }
 /// returns a texture id, this id is also used to identify the session
 pub fn create_new_playable(engine_handle: i64, vide_info: VideoInfo) -> i64 {
-    debug!("get_texture was called");
+    trace!("get_texture was called with engine_handle: {}, video_info: {:?}", engine_handle, vide_info);
     crate::core::fluttersink::create_new_playable(engine_handle, vide_info).unwrap()
 }
 
@@ -62,7 +64,5 @@ pub fn destroy_engine_streams(engine_id: i64) {
 
 pub fn destroy_stream_session(texture_id: i64) {
     trace!("destroy_stream_session was called");
-    invoke_on_platform_main_thread(move || {
         crate::core::fluttersink::destroy_stream_session(texture_id)
-    });
 }

--- a/rust/src/core/fluttersink/mod.rs
+++ b/rust/src/core/fluttersink/mod.rs
@@ -9,7 +9,7 @@ use std::{
 
 use log::{info, trace};
 
-use crate::core::software_decoder::SoftwareDecoder;
+use crate::{core::software_decoder::SoftwareDecoder, utils::invoke_on_platform_main_thread};
 
 use super::{software_decoder::SharedSendableTexture, types};
 
@@ -67,20 +67,29 @@ pub fn destroy_engine_streams(engine_handle: i64) {
 pub fn destroy_stream_session(texture_id: i64) {
     info!("Destroying stream session for texture id: {}", texture_id);
     let mut session_cache = SESSION_CACHE.lock().unwrap();
-    if let Some((decoder, _, _)) = session_cache.remove(&texture_id) {
+    if let Some((decoder, _, sendable_texture)) = session_cache.remove(&texture_id) {
         decoder.destroy_stream();
         let mut retry_count = 0;
-        while retry_count < 10 {
+        const MAX_RETRIES: usize = 30;
+        while retry_count < MAX_RETRIES {
             if Arc::strong_count(&decoder) == 1 {
-                break
+                break;
             }
-            info!("Waiting for all references to be dropped for texture id: {}", texture_id);
+            info!(
+                "Waiting for all references to be dropped for texture id: {}. attempt({})",
+                texture_id, retry_count
+            );
             thread::sleep(std::time::Duration::from_millis(100));
             retry_count += 1;
         }
-        // just for verbosity, it would have been dropped anyways..
-        drop(decoder); 
-        info!("Destroyed stream session for texture id: {}", texture_id);
+        if retry_count == MAX_RETRIES {
+            log::warn!("Forcefully dropped decoder for texture id: {},
+            the texture is held somewhere else thus would panic when unregistered if held on wrong thread.", texture_id);
+        }
+        invoke_on_platform_main_thread(move || {
+            drop(sendable_texture);
+            info!("Destroyed stream session for texture id: {}", texture_id);
+        });
     } else {
         info!("No stream session found for texture id: {}", texture_id);
     }

--- a/rust/src/core/fluttersink/mod.rs
+++ b/rust/src/core/fluttersink/mod.rs
@@ -83,8 +83,7 @@ pub fn destroy_stream_session(texture_id: i64) {
             retry_count += 1;
         }
         if retry_count == MAX_RETRIES {
-            log::warn!("Forcefully dropped decoder for texture id: {},
-            the texture is held somewhere else thus would panic when unregistered if held on wrong thread.", texture_id);
+            log::warn!("Forcefully dropped decoder for texture id: {}, the texture is held somewhere else and may panic when unregistered if held on the wrong thread.", texture_id);
         }
         invoke_on_platform_main_thread(move || {
             drop(sendable_texture);

--- a/rust/src/core/fluttersink/mod.rs
+++ b/rust/src/core/fluttersink/mod.rs
@@ -49,7 +49,7 @@ pub fn create_new_playable(
 
 pub fn destroy_engine_streams(engine_handle: i64) {
     info!("Destroying streams for engine handle: {}", engine_handle);
-    let mut session_cache = SESSION_CACHE.lock().unwrap();
+    let session_cache = SESSION_CACHE.lock().unwrap();
     let mut to_remove = vec![];
     for (texture_id, (decoder, handle, _)) in session_cache.iter() {
         if *handle == engine_handle {
@@ -58,14 +58,10 @@ pub fn destroy_engine_streams(engine_handle: i64) {
             to_remove.push(*texture_id);
         }
     }
+    drop(session_cache); // Release the lock before destroying sessions
     for texture_id in &to_remove {
-        session_cache.remove(&texture_id);
+        destroy_stream_session(*texture_id);
     }
-    info!(
-        "Destroyed {} streams for engine handle: {}",
-        to_remove.len(),
-        engine_handle
-    );
 }
 
 pub fn destroy_stream_session(texture_id: i64) {
@@ -73,6 +69,17 @@ pub fn destroy_stream_session(texture_id: i64) {
     let mut session_cache = SESSION_CACHE.lock().unwrap();
     if let Some((decoder, _, _)) = session_cache.remove(&texture_id) {
         decoder.destroy_stream();
+        let mut retry_count = 0;
+        while retry_count < 10 {
+            if Arc::strong_count(&decoder) == 1 {
+                break
+            }
+            info!("Waiting for all references to be dropped for texture id: {}", texture_id);
+            thread::sleep(std::time::Duration::from_millis(100));
+            retry_count += 1;
+        }
+        // just for verbosity, it would have been dropped anyways..
+        drop(decoder); 
         info!("Destroyed stream session for texture id: {}", texture_id);
     } else {
         info!("No stream session found for texture id: {}", texture_id);


### PR DESCRIPTION
## Summary by Sourcery

Enable dynamic stream URLs and multi-window playback in the example app, integrate desktop_multi_window support in the Linux runner, and harden the Rust backend by improving texture unregistration and expanding logging details

New Features:
- Add a text field for stream URL input and a button to open the stream in a new window in the example app
- Introduce a dedicated StreamWindowPage widget for multi-window playback using desktop_multi_window

Enhancements:
- Refactor Rust sink logic to release session cache locks before destroying sessions and streamline main-thread texture unregistration
- Implement retry logic to wait for all decoder references to drop before forcefully unregistering textures and emit warnings if forced
- Upgrade Rust logging to use trace level with thread names, file/line info, disable ANSI, and rename the log file

Build:
- Override irondash crate dependencies in Cargo.toml to use local path versions