### PR TITLE
Allow listening to same url twice + opt-in `autoDispose`

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -361,6 +361,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.28.0"
   screen_retriever:
     dependency: transitive
     description:

--- a/lib/video_player.dart
+++ b/lib/video_player.dart
@@ -49,7 +49,7 @@ class VideoController {
           dimensions: const VideoDimensions(width: 640, height: 360),
           mute: mute,
         ),
-      );
+      ).asBroadcastStream();
       final ret = VideoController(
         sessionId: sessionId,
         stateStream: stream,
@@ -61,7 +61,7 @@ class VideoController {
       // start ping task
       Future.microtask(() async {
         while (ret._running) {
-          // ping rust side to annonce we still want the stream.
+          // ping rust side to announce we still want the stream.
           rlib.markSessionAlive(sessionId: sessionId);
           await Future.delayed(const Duration(seconds: 1));
         }

--- a/lib/video_player.dart
+++ b/lib/video_player.dart
@@ -88,10 +88,16 @@ class VideoController {
 class VideoPlayer extends StatefulWidget {
   final VideoController controller;
   final Widget? child;
+
   /// whether to dispose the stream when the widget disposes?
-  final bool autoDispose ;
-  
-  const VideoPlayer._({super.key, required this.controller, this.child, this.autoDispose = true});
+  final bool autoDispose;
+
+  const VideoPlayer._({
+    super.key,
+    required this.controller,
+    this.child,
+    this.autoDispose = true,
+  });
 
   factory VideoPlayer.fromController({
     GlobalKey? key,
@@ -99,7 +105,12 @@ class VideoPlayer extends StatefulWidget {
     bool autoDispose = true,
     Widget? child,
   }) {
-    return VideoPlayer._(key: key, controller: controller, autoDispose: autoDispose, child: child);
+    return VideoPlayer._(
+      key: key,
+      controller: controller,
+      autoDispose: autoDispose,
+      child: child,
+    );
   }
 
   static Widget fromConfig({
@@ -197,23 +208,23 @@ class _VideoPlayerState extends State<VideoPlayer> {
   @override
   void dispose() {
     super.dispose();
-    
+
     Future.microtask(() async {
       streamSubscription?.cancel();
-      try {
-        if (kDebugMode) {
-          debugPrint(
-            'disposing stream session(${widget.controller.sessionId})',
-          );
-        }
-        if (widget.autoDispose){
-           await widget.controller.dispose();
-        }
-      } catch (e) {
-        if (kDebugMode) {
-          debugPrint(
-            'Error disposing session(${widget.controller.sessionId}): $e',
-          );
+      if (widget.autoDispose) {
+        try {
+          if (kDebugMode) {
+            debugPrint(
+              'disposing stream session(${widget.controller.sessionId})',
+            );
+          }
+          await widget.controller.dispose();
+        } catch (e) {
+          if (kDebugMode) {
+            debugPrint(
+              'Error disposing session(${widget.controller.sessionId}): $e',
+            );
+          }
         }
       }
     });

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -506,6 +506,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.2"
+  rxdart:
+    dependency: "direct main"
+    description:
+      name: rxdart
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.28.0"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   plugin_platform_interface: ^2.0.2
   irondash_engine_context:
   freezed_annotation: ^3.0.0
+  rxdart: ^0.28.0
         # git:
         #   url: "https://github.com/nrbnlulu/irondash.git"
         #   ref: dont-unregister-on-drop


### PR DESCRIPTION
## Summary by Sourcery

Enable broadcasting of stream state using rxdart’s BehaviorSubject to allow multiple concurrent listeners, and add an autoDispose option to manage controller cleanup from the VideoPlayer widget.

Enhancements:
- Wrap the StreamState stream in a BehaviorSubject and retain the original subscription for proper cancellation.
- Introduce an autoDispose flag on VideoPlayer to conditionally dispose the underlying VideoController when the widget unmounts.

Build:
- Add rxdart ^0.28.0 as a new dependency in pubspec.yaml